### PR TITLE
Fix syntax highlighting error for tilde blocks

### DIFF
--- a/syntax/madoko.vim
+++ b/syntax/madoko.vim
@@ -4,7 +4,10 @@ endif
 
 syn case ignore
 
-syn region madokoTildeBlock "\v^~*$"
+" This isn't quite accurate because it doesn't match the number of ~ at the start and end, as the
+" Madoko spec. indicates. However, I don't think that this can be done with Vim syntax highlighting,
+" so this may be the best approximation.
+syn region madokoTildeBlock start="\v^~*$" end="\v^~*$"
 
 syn include @tex syntax/tex.vim
 syn region madokoMath start="\v\$" end="\v\$" contains=@tex keepend


### PR DESCRIPTION
The current definition for tilde blocks causes a parsing error in Neovim (a complaint that not enough arguments are given to `syntax region`. This PR fixes that error. Note, however, that the patterns don't 100% match the Madoko spec because I'm not sure how to require the start and end patterns to have the same number of tildes (or if this is possible). It may be preferable to define multiple rules for different tilde "depths" up to some reasonable number, though this is inelegant at best.